### PR TITLE
Add remaining `TypedArray` codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ to build others on top. Feel free to PR more that are missing.
 * `cenc.float64` - Encodes a fixed size float64.
 * `cenc.buffer` - Encodes a buffer with its length uint prefixed. When decoding an empty buffer, `null` is returned.
 * `cenc.raw` - Pass through encodes a buffer, i.e. a basic copy.
-* `cenc.uint32array` - Encodes a uint32array with its element length uint32 prefixed.
+* `cenc.uint8array` - Encodes a uint8array with its element length uint prefixed.
+* `cenc.uint16array` - Encodes a uint16array with its element length uint prefixed.
+* `cenc.uint32array` - Encodes a uint32array with its element length uint prefixed.
+* `cenc.int8array` - Encodes a int8array with its element length uint prefixed.
+* `cenc.int16array` - Encodes a int16array with its element length uint prefixed.
+* `cenc.int32array` - Encodes a int32array with its element length uint prefixed.
 * `cenc.bool` - Encodes a boolean as 1 or 0.
 * `cenc.string` - Encodes a utf-8 string, similar to buffer.
 * `cenc.fixed32` - Encodes a fixed 32 byte buffer.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ to build others on top. Feel free to PR more that are missing.
 * `cenc.int8array` - Encodes a int8array with its element length uint prefixed.
 * `cenc.int16array` - Encodes a int16array with its element length uint prefixed.
 * `cenc.int32array` - Encodes a int32array with its element length uint prefixed.
+* `cenc.float32array` - Encodes a float32array with its element length uint prefixed.
+* `cenc.float64array` - Encodes a float64array with its element length uint prefixed.
 * `cenc.bool` - Encodes a boolean as 1 or 0.
 * `cenc.string` - Encodes a utf-8 string, similar to buffer.
 * `cenc.fixed32` - Encodes a fixed 32 byte buffer.

--- a/index.js
+++ b/index.js
@@ -234,6 +234,9 @@ exports.int8array = typedarray(Int8Array)
 exports.int16array = typedarray(Int16Array, b4a.swap16)
 exports.int32array = typedarray(Int32Array, b4a.swap32)
 
+exports.float32array = typedarray(Float32Array, b4a.swap32)
+exports.float64array = typedarray(Float64Array, b4a.swap64)
+
 exports.string = {
   preencode (state, s) {
     const len = b4a.byteLength(s)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const b = require('b4a')
+const b4a = require('b4a')
 
 const LE = (new Uint8Array(new Uint16Array([255]).buffer))[0] === 0xff
 const BE = !LE
@@ -163,21 +163,12 @@ exports.float64 = {
 
 exports.buffer = {
   preencode (state, b) {
-    if (b) {
-      uint.preencode(state, b.length)
-      state.end += b.length
-    } else {
-      state.end++
-    }
+    if (b) uint8array.preencode(state, b)
+    else state.end++
   },
   encode (state, b) {
-    if (b) {
-      uint.encode(state, b.length)
-      state.buffer.set(b, state.start)
-      state.start += b.length
-    } else {
-      state.buffer[state.start++] = 0
-    }
+    if (b) uint8array.encode(state, b)
+    else state.buffer[state.start++] = 0
   },
   decode (state) {
     const len = uint.decode(state)
@@ -203,57 +194,62 @@ const raw = exports.raw = {
   }
 }
 
-exports.uint32array = {
-  preencode (state, b) {
-    uint.preencode(state, b.length)
-    state.end += b.byteLength
-  },
-  encode (state, b) {
-    uint.encode(state, b.length)
-    const view = new Uint8Array(b.buffer, b.byteOffset, b.byteLength)
-    if (BE) hostToLE32(view, b.length)
-    state.buffer.set(view, state.start)
-    state.start += b.byteLength
-  },
-  decode (state) {
-    const len = uint.decode(state)
+function typedarray (TypedArray, swap) {
+  const n = TypedArray.BYTES_PER_ELEMENT
 
-    const byteOffset = state.buffer.byteOffset + state.start
-    const s = state.start
+  return {
+    preencode (state, b) {
+      uint.preencode(state, b.length)
+      state.end += b.byteLength
+    },
+    encode (state, b) {
+      uint.encode(state, b.length)
 
-    state.start += len * 4
+      const view = new Uint8Array(b.buffer, b.byteOffset, b.byteLength)
 
-    if ((byteOffset & 3) === 0) {
-      const arr = new Uint32Array(state.buffer.buffer, byteOffset, len)
-      if (BE) LEToHost32(arr, len)
-      return arr
+      if (BE && swap) swap(view)
+
+      state.buffer.set(view, state.start)
+      state.start += b.byteLength
+    },
+    decode (state) {
+      const len = uint.decode(state)
+
+      let b = state.buffer.subarray(state.start, state.start += len * n)
+      if (b.byteLength !== len * n) throw new Error('Out of bounds')
+      if (b.byteOffset % n !== 0) b = new Uint8Array(b)
+
+      if (BE && swap) swap(b)
+
+      return new TypedArray(b.buffer, b.byteOffset, b.byteLength / n)
     }
-
-    // align mismatch
-    const copy = new Uint8Array(len * 4)
-    const arr = new Uint32Array(copy.buffer, copy.byteOffset, len)
-    copy.set(state.buffer.subarray(s, state.start), 0)
-    if (BE) LEToHost32(arr, len)
-    return arr
   }
 }
 
+const uint8array = exports.uint8array = typedarray(Uint8Array)
+exports.uint16array = typedarray(Uint16Array, b4a.swap16)
+exports.uint32array = typedarray(Uint32Array, b4a.swap32)
+
+exports.int8array = typedarray(Int8Array)
+exports.int16array = typedarray(Int16Array, b4a.swap16)
+exports.int32array = typedarray(Int32Array, b4a.swap32)
+
 exports.string = {
   preencode (state, s) {
-    const len = b.byteLength(s)
+    const len = b4a.byteLength(s)
     uint.preencode(state, len)
     state.end += len
   },
   encode (state, s) {
-    const len = b.byteLength(s)
+    const len = b4a.byteLength(s)
     uint.encode(state, len)
-    b.write(state.buffer, s, state.start)
+    b4a.write(state.buffer, s, state.start)
     state.start += len
   },
   decode (state) {
     const len = uint.decode(state)
-    const s = b.toString(state.buffer, 'utf8', state.start, state.start += len)
-    if (b.byteLength(s) !== len || state.start > state.end) throw new Error('Out of bounds')
+    const s = b4a.toString(state.buffer, 'utf8', state.start, state.start += len)
+    if (b4a.byteLength(s) !== len || state.start > state.end) throw new Error('Out of bounds')
     return s
   }
 }
@@ -369,31 +365,13 @@ function fromAbstractEncoder (enc) {
 exports.encode = function encode (enc, m) {
   const state = { start: 0, end: 0, buffer: null }
   enc.preencode(state, m)
-  state.buffer = b.allocUnsafe(state.end)
+  state.buffer = b4a.allocUnsafe(state.end)
   enc.encode(state, m)
   return state.buffer
 }
 
 exports.decode = function decode (enc, buffer) {
   return enc.decode({ start: 0, end: buffer.byteLength, buffer })
-}
-
-function LEToHost32 (arr, len) {
-  const view = new DataView(arr.buffer, arr.byteOffset)
-  const host = new Uint32Array(arr.buffer, arr.byteOffset, len)
-
-  for (let i = 0; i < host.length; i++) {
-    host[i] = view.getUint32(4 * i, BE)
-  }
-}
-
-function hostToLE32 (arr, len) {
-  const view = new DataView(arr.buffer, arr.byteOffset)
-  const host = new Uint32Array(arr.buffer, arr.byteOffset, len)
-
-  for (let i = 0; i < host.length; i++) {
-    view.setUint32(4 * i, host[i], BE)
-  }
 }
 
 function zigZag (enc) {

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ function typedarray (TypedArray, swap) {
 
       let b = state.buffer.subarray(state.start, state.start += len * n)
       if (b.byteLength !== len * n) throw new Error('Out of bounds')
-      if (b.byteOffset % n !== 0) b = new Uint8Array(b)
+      if ((b.byteOffset % n) !== 0) b = new Uint8Array(b)
 
       if (BE && swap) swap(b)
 
@@ -251,7 +251,7 @@ exports.string = {
   },
   decode (state) {
     const len = uint.decode(state)
-    const s = b4a.toString(state.buffer, 'utf8', state.start, state.start += len)
+    const s = b4a.toString(state.buffer, 'utf-8', state.start, state.start += len)
     if (b4a.byteLength(s) !== len || state.start > state.end) throw new Error('Out of bounds')
     return s
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A series of compact encoding schemes for building small and fast parsers and serializers",
   "main": "index.js",
   "dependencies": {
-    "b4a": "^1.0.0"
+    "b4a": "^1.3.0"
   },
   "devDependencies": {
     "brittle": "^1.5.1",

--- a/test.js
+++ b/test.js
@@ -190,6 +190,23 @@ tape('raw', function (t) {
   t.is(state.start, state.end)
 })
 
+tape('uint16array', function (t) {
+  const state = enc.state()
+
+  enc.uint16array.preencode(state, new Uint16Array([1, 2, 3]))
+  t.alike(state, { start: 0, end: 7, buffer: null })
+
+  state.buffer = Buffer.alloc(state.end)
+  enc.uint16array.encode(state, new Uint16Array([1, 2, 3]))
+  t.alike(state, { start: 7, end: 7, buffer: Buffer.from([3, 1, 0, 2, 0, 3, 0]) })
+
+  state.start = 0
+  t.alike(enc.uint16array.decode(state), new Uint16Array([1, 2, 3]))
+  t.is(state.start, state.end)
+
+  t.exception(() => enc.uint16array.decode(state))
+})
+
 tape('uint32array', function (t) {
   const state = enc.state()
 
@@ -210,6 +227,42 @@ tape('uint32array', function (t) {
   t.is(state.start, state.end)
 
   t.exception(() => enc.uint32array.decode(state))
+})
+
+tape('int16array', function (t) {
+  const state = enc.state()
+
+  enc.int16array.preencode(state, new Int16Array([1, -2, 3]))
+  t.alike(state, { start: 0, end: 7, buffer: null })
+
+  state.buffer = Buffer.alloc(state.end)
+  enc.int16array.encode(state, new Int16Array([1, -2, 3]))
+  console.log(state.buffer)
+  t.alike(state, { start: 7, end: 7, buffer: Buffer.from([3, 1, 0, 0xfe, 0xff, 3, 0]) })
+
+  state.start = 0
+  t.alike(enc.int16array.decode(state), new Int16Array([1, -2, 3]))
+  t.is(state.start, state.end)
+
+  t.exception(() => enc.int16array.decode(state))
+})
+
+tape('int32array', function (t) {
+  const state = enc.state()
+
+  enc.int32array.preencode(state, new Int32Array([1, -2, 3]))
+  t.alike(state, { start: 0, end: 13, buffer: null })
+
+  state.buffer = Buffer.alloc(state.end)
+  enc.int32array.encode(state, new Int32Array([1, -2, 3]))
+  console.log(state.buffer)
+  t.alike(state, { start: 13, end: 13, buffer: Buffer.from([3, 1, 0, 0, 0, 0xfe, 0xff, 0xff, 0xff, 3, 0, 0, 0]) })
+
+  state.start = 0
+  t.alike(enc.int32array.decode(state), new Int32Array([1, -2, 3]))
+  t.is(state.start, state.end)
+
+  t.exception(() => enc.int16array.decode(state))
 })
 
 tape('string', function (t) {

--- a/test.js
+++ b/test.js
@@ -237,7 +237,6 @@ tape('int16array', function (t) {
 
   state.buffer = Buffer.alloc(state.end)
   enc.int16array.encode(state, new Int16Array([1, -2, 3]))
-  console.log(state.buffer)
   t.alike(state, { start: 7, end: 7, buffer: Buffer.from([3, 1, 0, 0xfe, 0xff, 3, 0]) })
 
   state.start = 0
@@ -255,14 +254,47 @@ tape('int32array', function (t) {
 
   state.buffer = Buffer.alloc(state.end)
   enc.int32array.encode(state, new Int32Array([1, -2, 3]))
-  console.log(state.buffer)
   t.alike(state, { start: 13, end: 13, buffer: Buffer.from([3, 1, 0, 0, 0, 0xfe, 0xff, 0xff, 0xff, 3, 0, 0, 0]) })
 
   state.start = 0
   t.alike(enc.int32array.decode(state), new Int32Array([1, -2, 3]))
   t.is(state.start, state.end)
 
-  t.exception(() => enc.int16array.decode(state))
+  t.exception(() => enc.int32array.decode(state))
+})
+
+tape('float32array', function (t) {
+  const state = enc.state()
+
+  enc.float32array.preencode(state, new Float32Array([1.1, -2.2, 3.3]))
+  t.alike(state, { start: 0, end: 13, buffer: null })
+
+  state.buffer = Buffer.alloc(state.end)
+  enc.float32array.encode(state, new Float32Array([1.1, -2.2, 3.3]))
+  t.alike(state, { start: 13, end: 13, buffer: Buffer.from([3, 0xcd, 0xcc, 0x8c, 0x3f, 0xcd, 0xcc, 0x0c, 0xc0, 0x33, 0x33, 0x53, 0x40]) })
+
+  state.start = 0
+  t.alike(enc.float32array.decode(state), new Float32Array([1.1, -2.2, 3.3]))
+  t.is(state.start, state.end)
+
+  t.exception(() => enc.float32array.decode(state))
+})
+
+tape('float64array', function (t) {
+  const state = enc.state()
+
+  enc.float64array.preencode(state, new Float64Array([1.1, -2.2, 3.3]))
+  t.alike(state, { start: 0, end: 25, buffer: null })
+
+  state.buffer = Buffer.alloc(state.end)
+  enc.float64array.encode(state, new Float64Array([1.1, -2.2, 3.3]))
+  t.alike(state, { start: 25, end: 25, buffer: Buffer.from([3, 0x9a, 0x99, 0x99, 0x99, 0x99, 0x99, 0xf1, 0x3f, 0x9a, 0x99, 0x99, 0x99, 0x99, 0x99, 0x01, 0xc0, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x0a, 0x40]) })
+
+  state.start = 0
+  t.alike(enc.float64array.decode(state), new Float64Array([1.1, -2.2, 3.3]))
+  t.is(state.start, state.end)
+
+  t.exception(() => enc.float64array.decode(state))
 })
 
 tape('string', function (t) {


### PR DESCRIPTION
The `LEToHost32()` and `hostToLE32()` functions had been bothering me for a while and with https://github.com/hypercore-skunkworks/b4a/commit/922a4eae78809e390bdaaaa2d0e1759bcaae8191 came a good opportunity to get rid of them. This PR does that and also introduces the remaining `TypedArray` codecs. Well, almost; `BigUint64Array` and `BigInt64Array` are still missing.