### PR TITLE
Add fixed size string codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,15 @@ to build others on top. Feel free to PR more that are missing.
 * `cenc.float64array` - Encodes a float64array with its element length uint prefixed.
 * `cenc.bool` - Encodes a boolean as 1 or 0.
 * `cenc.string`, `cenc.utf8` - Encodes a utf-8 string, similar to buffer.
+* `cenc.string.fixed(n)`, `cenc.utf8.fixed(n)` - Encodes a fixed sized utf-8 string.
 * `cenc.ascii` - Encodes an ascii string.
+* `cenc.ascii.fixed(n)` - Encodes a fixed size ascii string.
 * `cenc.hex` - Encodes a hex string.
+* `cenc.hex.fixed(n)` - Encodes a fixed size hex string.
 * `cenc.base64` - Encodes a base64 string.
+* `cenc.base64.fixed(n)` - Encodes a fixed size base64 string.
 * `cenc.utf16le`, `cenc.ucs2` - Encodes a utf16le string.
+* `cenc.utf16le.fixed(n)`, `cenc.ucs2.fixed(n)` - Encodes a fixed size utf16le string.
 * `cenc.fixed32` - Encodes a fixed 32 byte buffer.
 * `cenc.fixed64` - Encodes a fixed 64 byte buffer.
 * `cenc.fixed(n)` - Makes a fixed sized encoder.

--- a/index.js
+++ b/index.js
@@ -303,6 +303,21 @@ function string (encoding) {
       const len = uint.decode(state)
       if (state.end - state.start < len) throw new Error('Out of bounds')
       return b4a.toString(state.buffer, encoding, state.start, (state.start += len))
+    },
+    fixed (n) {
+      return {
+        preencode (state) {
+          state.end += n
+        },
+        encode (state, s) {
+          b4a.write(state.buffer, s, state.start, n, encoding)
+          state.start += n
+        },
+        decode (state) {
+          if (state.end - state.start < n) throw new Error('Out of bounds')
+          return b4a.toString(state.buffer, encoding, state.start, (state.start += n))
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Encountered something along the lines of this in some internal code:

```js
const hex32 = {
  preencode (state, x) {
    cenc.fixed32.preencode(state, Buffer.from(x, 'hex'))
  },
  encode (state, x) {
    cenc.fixed32.encode(state, Buffer.from(x, 'hex'))
  },
  decode (state, x) {
    return cenc.fixed32.decode(state).toString('hex')
  }
}
```

This PR introduces fixed size string codecs to accomplish the above as efficiently as possible, reducing it to `cenc.hex.fixed(32)`.